### PR TITLE
Modify API flow

### DIFF
--- a/app/controllers/pedidos_controller.rb
+++ b/app/controllers/pedidos_controller.rb
@@ -7,7 +7,7 @@ class PedidosController < ApplicationController
   end
 
   def create
-    @pedido = Pedido.new(pedido_params)
+    @pedido = Pedido.new(create_params)
 
     if @pedido.save!
       render "show", status: :created
@@ -15,7 +15,7 @@ class PedidosController < ApplicationController
   end
 
   def update
-    return render "show", status: :ok if @pedido.update(status: params[:status])
+    return render "show", status: :ok if @pedido.update(update_params)
 
     head :unprocessable_entity
   end
@@ -26,7 +26,11 @@ class PedidosController < ApplicationController
     @pedido = Pedido.find_by!(num_pedido: params[:num_pedido])
   end
 
-  def pedido_params
-    params.permit(:num_pedido, :status)
+  def create_params
+    params.permit(:num_pedido, itens_attributes: [:nome, :quantidade, :observacao]).merge(status: Pedido::DEFAULT_STATUS)
+  end
+
+  def update_params
+    params.permit(:num_pedido)
   end
 end

--- a/app/controllers/pedidos_controller.rb
+++ b/app/controllers/pedidos_controller.rb
@@ -31,6 +31,6 @@ class PedidosController < ApplicationController
   end
 
   def update_params
-    params.permit(:num_pedido)
+    params.permit(:num_pedido, :status)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,3 @@
+class Item < ApplicationRecord
+  belongs_to :pedido
+end

--- a/app/models/pedido.rb
+++ b/app/models/pedido.rb
@@ -1,10 +1,20 @@
 class Pedido < ApplicationRecord
-  enum status: {"recebido" => 0, "em_preparacao" => 1, "pronto" => 2, "finalizado" => 3}
+  enum status: {
+    "recebido" => 0,
+    "em_preparacao" => 1,
+    "pronto" => 2,
+    "finalizado" => 3
+  }
+
+  DEFAULT_STATUS = "recebido"
 
   validates :num_pedido, presence: true, uniqueness: true
   validates :status, presence: true
 
   after_update :notificar_pedidos_api, if: :finalizado?
+
+  has_many :itens, class_name: "Item"
+  accepts_nested_attributes_for :itens
 
   private
 

--- a/app/views/pedidos/_item.json.jbuilder
+++ b/app/views/pedidos/_item.json.jbuilder
@@ -1,0 +1,3 @@
+json.nome item.nome
+json.quantidade item.quantidade
+json.observacao item.observacao

--- a/app/views/pedidos/_pedido.json.jbuilder
+++ b/app/views/pedidos/_pedido.json.jbuilder
@@ -1,6 +1,11 @@
 if pedido
   json.num_pedido pedido.num_pedido
   json.status pedido.status
+  json.itens do
+    json.array! pedido.itens do |item|
+      json.partial! "pedidos/item", pedido: pedido, item: item
+    end
+  end
 else
   json.null
 end

--- a/app/views/pedidos/show.json.jbuilder
+++ b/app/views/pedidos/show.json.jbuilder
@@ -1,2 +1,1 @@
-json.num_pedido @pedido.num_pedido
-json.status @pedido.status
+json.partial! "pedidos/pedido", pedido: @pedido

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,11 +15,11 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV["DB_USER"] || producao %>
   password: <%= ENV["DB_PASSWORD"] || password %>
-  host: <%= ENV["DB_HOST"] || localhost %>
 
 development:
   <<: *default
   database: fiap_producao_api_development
+  host: <%= ENV["DB_HOST"] || localhost %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -27,6 +27,7 @@ development:
 test:
   <<: *default
   database: fiap_producao_api_test
+  host: <%= ENV["DB_HOST"] || localhost %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -53,3 +54,4 @@ production:
   database: fiap_producao_api_production
   username: fiap_producao_api
   password: <%= ENV["FIAP_PRODUCAO_API_DATABASE_PASSWORD"] %>
+  socket: <%= ENV["FIAP_PRODUCAO_API_DATABASE_SOCKET"] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,9 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
+  # Adds local endpoint
+  config.hosts << 'producao:3000'
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -7,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+  c.openapi_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/db/migrate/20240128202934_create_items.rb
+++ b/db/migrate/20240128202934_create_items.rb
@@ -1,0 +1,12 @@
+class CreateItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :items do |t|
+      t.references :pedido, null: false, foreign_key: true
+      t.string :nome
+      t.text :observacao
+      t.integer :quantidade
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_27_173646) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_28_202934) do
+  create_table "items", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "pedido_id", null: false
+    t.string "nome"
+    t.text "observacao"
+    t.integer "quantidade"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pedido_id"], name: "index_items_on_pedido_id"
+  end
+
   create_table "pedidos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "num_pedido"
     t.integer "status"
@@ -19,4 +29,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_27_173646) do
     t.index ["num_pedido"], name: "index_pedidos_on_num_pedido", unique: true
   end
 
+  add_foreign_key "items", "pedidos"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :item do
+    pedido_id { nil }
+    nome { "MyString" }
+    observacao { "MyText" }
+    quantidade { 1 }
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -17,15 +17,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    num_pedido:
-                      type: integer
-                    status:
-                      type: string
-                  required:
-                  - num_pedido
-                  - status
+                  $ref: '#/components/schemas/Pedido'
     post:
       summary: Enviar pedido para producao
       tags:
@@ -48,17 +40,7 @@ paths:
                 itens_attributes:
                   type: array
                   items:
-                    type: object
-                    properties:
-                      nome:
-                        type: string
-                        example: "X-Burger"
-                      quantidade:
-                        type: integer
-                        example: 1
-                      observacao:
-                        type: string
-                        example: "Sem picles"
+                    $ref: '#/components/schemas/Item'
               required:
               - num_pedido
               - itens_attributes
@@ -81,7 +63,7 @@ paths:
         description: Novo status do pedido
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/StatusPedido'
       responses:
         '200':
           description: Status do pedido atualizado com sucesso
@@ -94,3 +76,40 @@ servers:
   variables:
     defaultHost:
       default: localhost:3000
+
+components:
+  schemas:
+    Pedido:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Identificador local do pedido no sistema de produção
+        num_pedido:
+          type: string
+          description: Número do pedido global
+        status:
+          $ref: '#/components/schemas/StatusPedido'
+        itens:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+    Item:
+      type: object
+      properties:
+        nome:
+          type: string
+          example: "X-Burger"
+        observacao:
+          type: string
+          example: "Sem picles"
+        quantidade:
+          type: integer
+          example: 4
+    StatusPedido:
+      type: string
+      enum:
+        - criando
+        - em_preparacao
+        - pronto
+        - finalizado

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -44,11 +44,24 @@ paths:
               properties:
                 num_pedido:
                   type: integer
-                status:
-                  type: string
+                  example: 1
+                itens_attributes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      nome:
+                        type: string
+                        example: "X-Burger"
+                      quantidade:
+                        type: integer
+                        example: 1
+                      observacao:
+                        type: string
+                        example: "Sem picles"
               required:
               - num_pedido
-              - status
+              - itens_attributes
         required: true
   "/pedidos/{num_pedido}":
     parameters:


### PR DESCRIPTION
### Changed

- O endpoint de criar pedido deve aceitar o `num_pedido` e uma lista de itens com campos `nome`, `quantidade`, e `observacao`
- O serviço de produção deve guarder os itens de um pedido
- Aceita o socket pra conexão com banco de dados em produção
- Adiciona `producao:3000` como um host valido em desenvolvimento